### PR TITLE
    Faster searches for "sift -w WORD" word boundary searches.

### DIFF
--- a/matching.go
+++ b/matching.go
@@ -279,13 +279,16 @@ func getMatches(regex *regexp.Regexp, data []byte, testBuffer []byte, offset int
 			// analyze match and reject false matches
 			if !options.Multiline {
 				// remove newlines at the beginning of the match
+				skip := false
 				for ; start < length && end > start && data[start] == 0x0a; start++ {
+					skip = true
 				}
 				// remove newlines at the end of the match
 				for ; end > 0 && end > start && data[end-1] == 0x0a; end-- {
+					skip = true
 				}
 				// check if the corrected match is still valid
-				if !regex.Match(testBuffer[start:end]) {
+				if skip && !regex.Match(testBuffer[start:end]) {
 					continue
 				}
 				// check if the match contains newlines

--- a/matching.go
+++ b/matching.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"regexp"
+	"regexp/syntax"
 	"sort"
 )
 
@@ -173,6 +174,24 @@ func processReader(reader io.Reader, matchRegexes []*regexp.Regexp, data []byte,
 					if (!options.Multiline && m.lineEnd > prevMatch.lineEnd) ||
 						(options.Multiline && m.start >= prevMatch.end) {
 						validMatch = true
+					}
+				}
+				// work around the regexp engine when searching for a word flanked by word boundaries: \bWORD\b.
+				// When -w is set, omit the leading word boundary \b in the hope that WORD starts with a string literal,
+				// which can be quickly searched for before entering the slower regex engine.
+				// Enforce the leading word boundary requirement here. \b == \A\w or \W\w or \w\W or \w\z
+				// \w\z is out as a possibility because the pattern has a trailing \b
+				if options.WordRegexp && validMatch {
+					if syntax.IsWordChar(rune(newMatches[i].line[newMatches[i].start-newMatches[i].lineStart])) {
+						// \A\w or \W\w
+						if !(newMatches[i].start == newMatches[i].lineStart || !syntax.IsWordChar(rune(newMatches[i].line[newMatches[i].start-1-newMatches[i].lineStart]))) {
+							validMatch = false
+						}
+					} else {
+						// \w\W
+						if !(newMatches[i].start > newMatches[i].lineStart && syntax.IsWordChar(rune(newMatches[i].line[newMatches[i].start-1-newMatches[i].lineStart]))) {
+							validMatch = false
+						}
 					}
 				}
 				if validMatch {

--- a/options.go
+++ b/options.go
@@ -507,7 +507,7 @@ func (o *Options) preparePattern(pattern string) string {
 		pattern = strings.ToLower(pattern)
 	}
 	if o.WordRegexp {
-		pattern = `\b` + pattern + `\b`
+		pattern = pattern + `\b`
 	}
 	pattern = "(?m)" + pattern
 	if o.Multiline {


### PR DESCRIPTION
    Equivalent to matching the regex \bWORD\b.

    Shift the order in which characters of the haystack are compared to the needle. Instead of starting the search on a word boundary (\b), start with WORD\b. When WORD has a string literal prefix (a common use case), searching for it is more efficient because it occurs less frequently (in most texts) and is faster because it bypasses the regex engine [1]. As a second step, enforce the leading word boundary condition over a much smaller haystack, without a regex.

    [1] https://github.com/golang/go/blob/a064a4f29a97a4fc7398d1ac9d7c53c5ba0bc646/src/regexp/backtrack.go#L341

    TL;DR it's faster to search for literals first.

    Observed 16x speedup for the following pattern and directory:
    sift -q "\bWaitForConnect\b" $m/mist-ap  2.62s user 0.08s system 555% cpu 0.486 total
    sift -w -q "WaitForConnect" $m/mist-ap  0.08s user 0.10s system 570% cpu 0.032 total

    ** HOWEVER, there is a bug in sift that fails to find any matches for patterns that start with "\b\W". ***